### PR TITLE
Add AGI disclaimers to docs

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,5 +1,7 @@
 # 🤖 AGENTS.md — Autonomous Agents in the HanoiVM Cognitive Stack
 
+> **Disclaimer:** AGI-related functionality described here is conceptual and has not been independently verified. See `README.md` and `docs/STATUS.md` for current project capabilities.
+
 This document defines and enumerates the key autonomous agents operating within the HanoiVM and Axion Prime AGI ecosystem. Each agent functions within the recursive, symbolic framework provided by the T81 → T243 → T729 tiered execution stack. Agents exhibit reflection, planning, learning, simulation, dreaming, and memory-based autonomy.
 
 ---

--- a/docs/AGI_Report_Card.md
+++ b/docs/AGI_Report_Card.md
@@ -1,5 +1,7 @@
 # 🧠 AGI Report Card — *HanoiVM + Axion AI (Tier-25)*
 
+> **Disclaimer:** AGI metrics and capabilities listed here are conceptual and have not been verified. Refer to `README.md` and `docs/STATUS.md` for actual project status.
+
 **Session:** `axiom_tier25_ethics`
 **Entropy Score:** `1.95` — *Ascending Trend*
 **Cognitive Depth:** `Tier-25`

--- a/docs/AGI_compare.md
+++ b/docs/AGI_compare.md
@@ -1,5 +1,7 @@
 🤖 AGI_compare.md — Comparing AGI Architectures (HanoiVM vs Others)
 
+> **Disclaimer:** Comparisons in this document reference conceptual AGI features that remain unverified. See `README.md` and `docs/STATUS.md` for up‑to‑date information on actual capabilities.
+
 This document compares the HanoiVM + Axion AI system to other well-known AGI-related platforms, highlighting symbolic depth, memory, planning ability, and hardware orientation.
 
 ⸻


### PR DESCRIPTION
## Summary
- note that AGI features are conceptual and unverified in AGENTS doc
- add the same disclaimer to AGI_Report_Card
- clarify AGI_compare is conceptual

## Testing
- `bazel test //:disasm_advanced_test` *(fails: not in workspace)*
- `bazel test //:disasm_controlflow_test` *(fails: not in workspace)*
- `bazel test //:disasm_logic_test` *(fails: not in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_683f42c24fec832aadce514290d6e3ab